### PR TITLE
Remove deprecated @angular/animations and platform-browser-dynamic

### DIFF
--- a/mystic-vale/package-lock.json
+++ b/mystic-vale/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@angular/animations": "^22.0.2",
         "@angular/cdk": "^22.0.2",
         "@angular/common": "^22.0.2",
         "@angular/compiler": "^22.0.2",
@@ -17,7 +16,6 @@
         "@angular/forms": "^22.0.2",
         "@angular/material": "^22.0.2",
         "@angular/platform-browser": "^22.0.2",
-        "@angular/platform-browser-dynamic": "^22.0.2",
         "@angular/router": "^22.0.2",
         "@types/webpack-env": "^1.18.8",
         "core-js": "^3.49.0",
@@ -459,22 +457,6 @@
         "typescript": "*"
       }
     },
-    "node_modules/@angular/animations": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.2.tgz",
-      "integrity": "sha512-l9lVG9k+baFMWXNsFUxwmxQaUZMkpkTn3vRpa1hs/vABzT/KnaDeweDtvvkS0NS1RYJenoxhONlMNEWuJ4VR1A==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.2"
-      }
-    },
     "node_modules/@angular/build": {
       "version": "22.0.3",
       "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.3.tgz",
@@ -806,25 +788,6 @@
         "@angular/animations": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-22.0.2.tgz",
-      "integrity": "sha512-5jDZzbesBBPCt41oq166B23TCW4ue9ZJyX4KlSRpGP/x8fjPGF22+AKASU6OPRnCNmmUsNk8DpenaBj+eFg/Sw==",
-      "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "22.0.2",
-        "@angular/compiler": "22.0.2",
-        "@angular/core": "22.0.2",
-        "@angular/platform-browser": "22.0.2"
       }
     },
     "node_modules/@angular/router": {

--- a/mystic-vale/package.json
+++ b/mystic-vale/package.json
@@ -15,7 +15,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.2",
     "@angular/cdk": "^22.0.2",
     "@angular/common": "^22.0.2",
     "@angular/compiler": "^22.0.2",
@@ -23,7 +22,6 @@
     "@angular/forms": "^22.0.2",
     "@angular/material": "^22.0.2",
     "@angular/platform-browser": "^22.0.2",
-    "@angular/platform-browser-dynamic": "^22.0.2",
     "@angular/router": "^22.0.2",
     "@types/webpack-env": "^1.18.8",
     "core-js": "^3.49.0",

--- a/mystic-vale/src/app/app.component.spec.ts
+++ b/mystic-vale/src/app/app.component.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AppComponent } from './app.component';
 import { ConclaveService } from './conclave.service';
 
@@ -7,7 +6,6 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         AppComponent
       ],
       providers: [ConclaveService],

--- a/mystic-vale/src/app/app.module.ts
+++ b/mystic-vale/src/app/app.module.ts
@@ -1,5 +1,4 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
@@ -13,7 +12,6 @@ import { ConclaveService } from './conclave.service';
   ],
   imports: [
     BrowserModule,
-    BrowserAnimationsModule,
     FormsModule
   ],
   providers: [ConclaveService],

--- a/mystic-vale/src/app/conclave-settings/conclave-settings.component.spec.ts
+++ b/mystic-vale/src/app/conclave-settings/conclave-settings.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ConclaveSettingsComponent } from './conclave-settings.component';
 import { ConclaveService } from '../conclave.service';
@@ -10,7 +9,7 @@ describe('ConclaveSettingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ConclaveSettingsComponent, NoopAnimationsModule],
+      imports: [ConclaveSettingsComponent],
       providers: [ConclaveService],
     })
     .compileComponents();

--- a/mystic-vale/src/app/conclave-settings/conclave-settings.interaction.spec.ts
+++ b/mystic-vale/src/app/conclave-settings/conclave-settings.interaction.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ConclaveSettingsComponent } from './conclave-settings.component';
 import { ConclaveService } from '../conclave.service';
@@ -9,7 +8,7 @@ describe('ConclaveSettingsComponent interaction', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ConclaveSettingsComponent, NoopAnimationsModule],
+      imports: [ConclaveSettingsComponent],
       providers: [ConclaveService],
     }).compileComponents();
 

--- a/mystic-vale/src/main.ts
+++ b/mystic-vale/src/main.ts
@@ -1,5 +1,5 @@
 import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { platformBrowser } from '@angular/platform-browser';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -8,5 +8,5 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()], })
+platformBrowser().bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()], })
   .catch(err => console.log(err));


### PR DESCRIPTION
Both `@angular/animations` and `@angular/platform-browser-dynamic` are deprecated in Angular 22. This removes them and switches to the supported replacements.

## Changes

- **`@angular/platform-browser-dynamic`**: `src/main.ts` now bootstraps with `platformBrowser()` from `@angular/platform-browser` instead of `platformBrowserDynamic()`. This works with the Ivy/AOT pipeline the build already uses.
- **`@angular/animations`**: Dropped entirely. It was only pulled in transitively via `BrowserAnimationsModule` (in `app.module.ts`) and `NoopAnimationsModule` (in three spec files). Angular Material 22 uses native CSS animations and no longer requires the animations engine, and `@angular/animations` is only an optional peer of `@angular/platform-browser`, so removing it is safe.
- Removed both packages from `package.json` and refreshed `package-lock.json`.

## Notes

The remaining `@angular/animations` reference in `package-lock.json` is just `@angular/platform-browser`'s optional peer-dependency declaration; the package itself is no longer installed.

## Verification

`npm run build`, `npm run test-headless` (13/13 passing), and `npm run lint` all pass.